### PR TITLE
Fixed susceptibility function behaviour in practical 9

### DIFF
--- a/inst/scripts/09_StochasticIBM/02_RevIBM.R
+++ b/inst/scripts/09_StochasticIBM/02_RevIBM.R
@@ -24,7 +24,7 @@ infectiousness <- function(state, age) {
 
 # Calculates susceptibility of individuals with antibody level(s) ab
 susceptibility <- function(ab) {
-    pnorm(ab, 5, 1)
+    1 - pnorm(ab, 5, 1)
 }
 
 # Generates n random delays from the latent-period distribution

--- a/inst/scripts/09_StochasticIBM/03_Rev2IBM.R
+++ b/inst/scripts/09_StochasticIBM/03_Rev2IBM.R
@@ -22,7 +22,7 @@ infectiousness <- function(state, age) {
 
 # Calculates susceptibility of individuals with antibody level(s) ab
 susceptibility <- function(ab) {
-    pnorm(ab, 5, 1)
+    1 - pnorm(ab, 5, 1)
 }
 
 # Generates n random delays from the latent-period distribution
@@ -88,7 +88,7 @@ for (ts in 1:steps) {
     # Update state variables (for all individuals simultaneously)
     ##### trE selects all individuals who will transition states from S to E.
     trE <- (state == "S") & (runif(n) < 1 - exp(-lambda * dt)) &
-      (runif(n) > susceptibility(antib))
+      (runif(n) < susceptibility(antib))
     trI <- ... ##### Fill in similar conditions for trI (E->I) and trS (I->S).
     trS <- ...
 

--- a/inst/solutions/09_StochasticIBM/02_RevIBM.R
+++ b/inst/solutions/09_StochasticIBM/02_RevIBM.R
@@ -22,7 +22,7 @@ infectiousness <- function(state, age) {
 
 # Calculates susceptibility of individuals with antibody level(s) ab
 susceptibility <- function(ab) {
-    pnorm(ab, 5, 1)
+    1 - pnorm(ab, 5, 1)
 }
 
 # Generates n random delays from the latent-period distribution
@@ -88,11 +88,10 @@ for (ts in 1:steps) {
         # Update individual i's state
         if (state[i] == "S") {
             # Transition S -> E (infection) at rate lambda
-            if (runif(1) < 1 - exp(-lambda * dt)) {
-                if (runif(1) > susceptibility(antib[i])) {
-                    state[i] <- "E"
-                    delay[i] <- latent_delay(1)
-                }
+            if (runif(1) < 1 - exp(-lambda * dt) & 
+                  runif(1) < susceptibility(antib[i])) {
+                state[i] <- "E"
+                delay[i] <- latent_delay(1)
             }
         } else if (state[i] == "E") {
             # Transition E -> I (latent to infectious)

--- a/inst/solutions/09_StochasticIBM/03_Rev2IBM.R
+++ b/inst/solutions/09_StochasticIBM/03_Rev2IBM.R
@@ -22,7 +22,7 @@ infectiousness <- function(state, age) {
 
 # Calculates susceptibility of individuals with antibody level(s) ab
 susceptibility <- function(ab) {
-    pnorm(ab, 5, 1)
+    1 - pnorm(ab, 5, 1)
 }
 
 # Generates n random delays from the latent-period distribution
@@ -88,7 +88,7 @@ for (ts in 1:steps) {
     # Update state variables (for all individuals simultaneously)
     ##### trE selects all individuals who will transition states from S to E.
     trE <- (state == "S") & (runif(n) < 1 - exp(-lambda * dt)) &
-      (runif(n) > susceptibility(antib))
+      (runif(n) < susceptibility(antib))
     trI <- (state == "E") & (delay < 0)
     trS <- (state == "I") & (delay < 0)
 


### PR DESCRIPTION
The function was returning 1 - susceptibility rather than susceptibility. The code using this function was written correctly to account for this, but it's potentially confusing. So I have fixed the function to return susceptibility proper and the code relying on it to adjust to this new behaviour.

Note that the first file here, `inst/scripts/09_StochasticIBM/02_RevIBM.R` only defines the function, doesn't use it, so no changes to the later code were needed. All the other 3 scripts/solution scripts with changes here both define and use the function, so there are two changes per script, one to the function definition and one to the use of the function later on in the code, where the needed change is from a `>` operator to a `<` operator.